### PR TITLE
Fix côté front : overflow-x et ajout de type/name

### DIFF
--- a/front/src/components/AdminContributorsList/AdminContributorsList.vue
+++ b/front/src/components/AdminContributorsList/AdminContributorsList.vue
@@ -15,8 +15,9 @@
           <div class="col-lg-1 d-flex justify-content-center align-items-center">
             <b-form-checkbox class="mr-0" v-model="checked" v-on:change="all ($event)"></b-form-checkbox>
           </div>
+          <p class="col-lg-1 my-auto text-center text-uppercase">Type</p>
           <p class="col-lg-1 my-auto text-center text-uppercase">Order</p>
-          <p class="col-lg-3 my-auto text-uppercase">Contribution</p>
+          <p class="col-lg-2 my-auto text-center text-uppercase">Name</p>
           <p class="col-lg-2 my-auto text-center text-uppercase">Last request</p>
           <p class="col-lg-2 my-auto text-center text-uppercase">Last iteration</p>
           <p class="col-lg-1 my-auto text-center text-uppercase">Status</p>
@@ -30,6 +31,7 @@
             v-if="(contribution.department == selectedDepartment || selectedDepartment == 'all') && (contribution.period == selectedPeriodicity || selectedPeriodicity == 'all')"
             v-bind:key="index"
             v-bind:checked="contribution.checked"
+            v-bind:department_name="contribution.department_name"
             v-bind:order="contribution.contribution_order"
             v-bind:name="contribution.contribution_name"
             v-bind:starts_at="contribution.version_starts_at"

--- a/front/src/components/AdminContributorsListItem/AdminContributorsListItem.vue
+++ b/front/src/components/AdminContributorsListItem/AdminContributorsListItem.vue
@@ -7,10 +7,14 @@
       </div>
 
       <p class="col-lg-1 my-auto text-center">
+        {{ department_name }}
+      </p>
+
+      <p class="col-lg-1 my-auto text-center">
         {{ order }}
       </p>
 
-      <p class="col-lg-3 my-auto">
+      <p class="col-lg-2 my-auto">
         {{ name }}
       </p>
 
@@ -56,7 +60,8 @@ export default {
     'modified_at',
     'status_admin',
     'contribution_id',
-    'version_id'
+    'version_id',
+    'department_name'
   ],
 
   data () {

--- a/front/src/components/AdminNewCampaign/AdminNewCampaign.vue
+++ b/front/src/components/AdminNewCampaign/AdminNewCampaign.vue
@@ -284,6 +284,7 @@ export default {
 #AdminNewCampaign .list-group {
   max-height: 160px;
   overflow: scroll;
+  overflow-x:hidden;
 }
 
 #AdminNewCampaign #message {


### PR DESCRIPTION
Ajout de overflow-x:hidden sur AdminNew Campaign pour cacher la scrollbar.
Ajout d'une nouvelle infos sur la page de la liste des contributions côté admin : Type (pour afficher le type) et mise à jour de "contribution" en "name".